### PR TITLE
Add fishplot remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: Apache License 2.0
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
+Remotes: chrisamiller/fishplot
 Imports:
     dplyr,
     tidyr,

--- a/README.Rmd
+++ b/README.Rmd
@@ -85,9 +85,6 @@ You can install epifish with:
 install.packages("devtools")
 library(devtools)
 
-#install fishplot if you haven't already
-devtools::install_github("chrisamiller/fishplot")
-
 #install epifish
 devtools::install_github("learithe/epifish")
 ```

--- a/README.md
+++ b/README.md
@@ -82,9 +82,6 @@ You can install epifish with:
 install.packages("devtools")
 library(devtools)
 
-#install fishplot if you haven't already
-devtools::install_github("chrisamiller/fishplot")
-
 #install epifish
 devtools::install_github("learithe/epifish")
 ```


### PR DESCRIPTION
By using the [`Remotes` header](https://remotes.r-lib.org/articles/dependencies.html), package managers [including `devtools`](https://devtools.r-lib.org/articles/dependencies.html) will know to fetch the `fishplot` package from GitHub and so the separate manual installation is not required. It makes installation self-contained.